### PR TITLE
Fix installation commands code block in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To install Homebrew, visit https://brew.sh/.
 Once Homebrew is installed, you can add the Mondoo Tap via the following command:
 
 ```
-$ brew tap mondoohq/mondoo
+brew tap mondoohq/mondoo
 ```
 
 To install cnquery/cnspec:
@@ -39,7 +39,7 @@ For more information, visit https://mondoo.com
 To freshen the Cask and Formula to the latest release of the Mondoo client, simply run ```make update```, and commit the result:
 
 ```
-$ make update
+make update
 ```
 
 ### Join the community!


### PR DESCRIPTION
Removed `$` sign which is copied with command when using the copy button associated with the code block.