### PR TITLE
ci: open and squash-merge release PR instead of pushing to master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,14 +81,31 @@ jobs:
         run: |
           git diff --color
 
-      - name: commit
+      # Open a PR and merge it immediately. Direct pushes to master are
+      # blocked by an org ruleset (PR required), and "Allow auto-merge" is
+      # disabled on this repo, so we merge via the API right after opening
+      # the PR. Required reviews on master are 0, so the merge succeeds
+      # without human intervention.
+      - name: open and merge release PR
         if: ${{ ! inputs.skip-publish }}
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          echo '${{ steps.version.outputs.version }}'
+          BRANCH="release/v${VERSION}-${GITHUB_RUN_ID}"
+          git checkout -b "${BRANCH}"
           git add Formula/cnquery.rb
           git add Formula/cnspec.rb
           git add Formula/mql.rb
           git add Casks/mondoo-cli.rb
           git add Casks/mondoo.rb
-          git commit -m '${{ steps.version.outputs.version }}'
-          git push origin master
+          git commit -m "${VERSION}"
+          git push origin "${BRANCH}"
+          PR_URL=$(gh pr create \
+            --repo mondoohq/homebrew-mondoo \
+            --base master \
+            --head "${BRANCH}" \
+            --title "${VERSION}" \
+            --body "Automated release bump for ${VERSION}")
+          echo "Opened: ${PR_URL}"
+          gh pr merge "${PR_URL}" --squash


### PR DESCRIPTION
## Summary
- Direct pushes to master are blocked by an org ruleset (PR required); the v13.7.0 release run failed with `GH013: Changes must be made through a pull request` ([failed run](https://github.com/mondoohq/installer/actions/runs/25044723107/job/73357753783)).
- "Allow auto-merge" is disabled on this repo, so we open a PR with \`gh pr create\` and immediately squash-merge it with \`gh pr merge --squash\`. Required approving reviews on master are 0, so the merge succeeds without human intervention.
- Moves \`VERSION\` out of \`\${{ }}\` shell interpolation into an \`env:\` block + \`\$VAR\` shell expansion (safer pattern; eliminates the prior shell-injection surface in the commit message).

## Prerequisite (one-time, not per-release)
The \`mondoo-mergebot\` GitHub App installation on \`mondoohq/homebrew-mondoo\` needs \`pull-requests: write\` added (it currently has only \`contents: write\`). Without it, \`gh pr create\` / \`gh pr merge\` will 403.

## Test plan
- [ ] Add \`pull-requests: write\` to the mondoo-mergebot App installation on this repo.
- [ ] Re-run \`v13.7.0 PKG: Package, Release, Reindex\` on \`mondoohq/installer\` (or trigger via \`workflow_dispatch\` here with \`skip-publish: false\`) and confirm a release branch is pushed, a PR is opened, and the PR is merged automatically.
- [ ] Confirm the release branch is auto-deleted (repo has \`delete_branch_on_merge\` enabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)